### PR TITLE
Build internal graph with petgraph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
 name = "engine"
 version = "0.1.0"
 dependencies = [
+ "petgraph",
  "wasm-bindgen",
  "wgpu",
 ]
@@ -191,6 +192,12 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "foreign-types"
@@ -532,6 +539,16 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "pkg-config"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -11,3 +11,4 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = "0.2"
 wgpu = { version = "0.19", default-features = false, features = ["webgpu"], optional = true }
+petgraph = "0.6"

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod chunk;
 pub mod csr;
 pub mod layout;
+pub mod scc;
 
 pub use chunk::{
     parse_chunk, validate_chunk, Action, Connection, Error, MycosChunk, Section, Trigger,
@@ -9,3 +10,4 @@ pub use csr::{build_csr, Effect, CSR};
 pub use layout::{
     bit_to_word, clr_bit, connection_table_offset, section_offsets, set_bit, xor_bit, HEADER_BYTES,
 };
+pub use scc::build_internal_graph;

--- a/engine/src/scc.rs
+++ b/engine/src/scc.rs
@@ -1,0 +1,59 @@
+use crate::chunk::{MycosChunk, Section};
+use petgraph::graph::{DiGraph, NodeIndex};
+
+pub fn build_internal_graph(chunk: &MycosChunk) -> DiGraph<(), ()> {
+    let mut graph = DiGraph::<(), ()>::new();
+    let nodes: Vec<NodeIndex> = (0..chunk.internal_count)
+        .map(|_| graph.add_node(()))
+        .collect();
+
+    for conn in &chunk.connections {
+        if matches!(conn.from_section, Section::Internal)
+            && matches!(conn.to_section, Section::Internal)
+        {
+            let from = conn.from_index as usize;
+            let to = conn.to_index as usize;
+            graph.add_edge(nodes[from], nodes[to], ());
+        }
+    }
+
+    graph
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chunk::{parse_chunk, validate_chunk};
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn fixtures() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("fixtures")
+    }
+
+    #[test]
+    fn graph_node_and_edge_counts_match() {
+        for entry in fs::read_dir(fixtures()).unwrap() {
+            let entry = entry.unwrap();
+            if entry.path().extension().and_then(|s| s.to_str()) == Some("myc") {
+                let data = fs::read(entry.path()).unwrap();
+                let chunk = parse_chunk(&data).unwrap();
+                validate_chunk(&chunk).unwrap();
+                let graph = build_internal_graph(&chunk);
+
+                assert_eq!(graph.node_count() as u32, chunk.internal_count);
+                let expected_edges = chunk
+                    .connections
+                    .iter()
+                    .filter(|c| {
+                        matches!(c.from_section, Section::Internal)
+                            && matches!(c.to_section, Section::Internal)
+                    })
+                    .count();
+                assert_eq!(graph.edge_count(), expected_edges);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `petgraph` dependency
- build directed graph of internal→internal edges
- expose graph builder and test node/edge counts

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_68995365d1d88325baab1a8b80854567