### PR TITLE
Add SCC condensation with topological levels

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -10,4 +10,4 @@ pub use csr::{build_csr, Effect, CSR};
 pub use layout::{
     bit_to_word, clr_bit, connection_table_offset, section_offsets, set_bit, xor_bit, HEADER_BYTES,
 };
-pub use scc::build_internal_graph;
+pub use scc::{build_internal_graph, scc_ids_and_topo_levels};


### PR DESCRIPTION
## Summary
- compute strongly connected components for internal bits using Kosaraju's algorithm
- derive condensation DAG and topo levels for diagnostics
- test oscillator_2cycle fixture to ensure SCC detection

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_689957f2b340832597b72d1775f9da24