### PR TITLE
Add global bit offset mapping for inter-chunk links

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -11,5 +11,8 @@ pub use csr::{build_csr, Effect, CSR};
 pub use layout::{
     bit_to_word, clr_bit, connection_table_offset, section_offsets, set_bit, xor_bit, HEADER_BYTES,
 };
-pub use link::{parse_links, validate_links, Link, LinkError};
+pub use link::{
+    build_link_csr, compute_base_offsets, parse_links, validate_links, ChunkOffsets, Link,
+    LinkError,
+};
 pub use scc::{build_internal_graph, scc_ids_and_topo_levels};

--- a/engine/src/link.rs
+++ b/engine/src/link.rs
@@ -1,4 +1,6 @@
 use crate::chunk::{Action, MycosChunk, Trigger};
+use crate::csr::{Effect, CSR};
+use crate::layout::bit_to_word;
 
 #[derive(Debug)]
 pub struct Link {
@@ -95,6 +97,144 @@ pub fn validate_links(links: &[Link], chunks: &[MycosChunk]) -> Result<(), LinkE
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChunkOffsets {
+    pub input: u32,
+    pub output: u32,
+    pub internal: u32,
+}
+
+/// Compute base offsets for Inputs, Outputs, and Internals of each chunk.
+///
+/// Offsets are expressed in **bits** relative to the start of the global
+/// device buffers for each section. They are used to map per-chunk bit indices
+/// to global identifiers when linking multiple chunks together.
+pub fn compute_base_offsets(chunks: &[MycosChunk]) -> Vec<ChunkOffsets> {
+    let mut offs = Vec::with_capacity(chunks.len());
+    let mut base_in = 0u32;
+    let mut base_out = 0u32;
+    let mut base_int = 0u32;
+    for ch in chunks {
+        offs.push(ChunkOffsets {
+            input: base_in,
+            output: base_out,
+            internal: base_int,
+        });
+        base_in += ch.input_count;
+        base_out += ch.output_count;
+        base_int += ch.internal_count;
+    }
+    offs
+}
+
+/// Build a CSR adjacency for inter-chunk links using global bit ids.
+///
+/// Sources are chunk **outputs**; targets are **inputs** of other chunks.
+/// The returned `CSR` can be processed exactly like intra-chunk connections
+/// during expansion.
+pub fn build_link_csr(links: &[Link], chunks: &[MycosChunk]) -> CSR {
+    let offsets = compute_base_offsets(chunks);
+    let out_total = chunks.iter().map(|c| c.output_count).sum::<u32>() as usize;
+
+    let mut offs_on = vec![0u32; out_total + 1];
+    let mut offs_off = vec![0u32; out_total + 1];
+    let mut offs_tog = vec![0u32; out_total + 1];
+
+    for link in links {
+        let from = offsets[link.from_chunk as usize].output + link.from_out_idx;
+        let from = from as usize;
+        match link.trigger {
+            Trigger::On => offs_on[from + 1] += 1,
+            Trigger::Off => offs_off[from + 1] += 1,
+            Trigger::Toggle => offs_tog[from + 1] += 1,
+        }
+    }
+
+    for i in 0..out_total {
+        offs_on[i + 1] += offs_on[i];
+        offs_off[i + 1] += offs_off[i];
+        offs_tog[i + 1] += offs_tog[i];
+    }
+
+    let base_off = offs_on[out_total];
+    let base_tog = base_off + offs_off[out_total];
+    for v in &mut offs_off {
+        *v += base_off;
+    }
+    for v in &mut offs_tog {
+        *v += base_tog;
+    }
+
+    let mut effects = vec![Effect::default(); links.len()];
+    let mut next_on = offs_on[..out_total].to_vec();
+    let mut next_off = offs_off[..out_total].to_vec();
+    let mut next_tog = offs_tog[..out_total].to_vec();
+
+    for link in links {
+        let from = offsets[link.from_chunk as usize].output + link.from_out_idx;
+        let to = offsets[link.to_chunk as usize].input + link.to_in_idx;
+        let (to_word, mask) = bit_to_word(to);
+        let effect = Effect {
+            to_word,
+            mask,
+            action: link.action,
+            order_tag: link.order_tag,
+            to_is_internal: false,
+            to_bit: to,
+        };
+        match link.trigger {
+            Trigger::On => {
+                let idx = next_on[from as usize] as usize;
+                effects[idx] = effect;
+                next_on[from as usize] += 1;
+            }
+            Trigger::Off => {
+                let idx = next_off[from as usize] as usize;
+                effects[idx] = effect;
+                next_off[from as usize] += 1;
+            }
+            Trigger::Toggle => {
+                let idx = next_tog[from as usize] as usize;
+                effects[idx] = effect;
+                next_tog[from as usize] += 1;
+            }
+        }
+    }
+
+    for i in 0..out_total {
+        let start = offs_on[i] as usize;
+        let end = offs_on[i + 1] as usize;
+        effects[start..end].sort_by(|a, b| {
+            a.to_word
+                .cmp(&b.to_word)
+                .then(a.order_tag.cmp(&b.order_tag))
+        });
+
+        let start = offs_off[i] as usize;
+        let end = offs_off[i + 1] as usize;
+        effects[start..end].sort_by(|a, b| {
+            a.to_word
+                .cmp(&b.to_word)
+                .then(a.order_tag.cmp(&b.order_tag))
+        });
+
+        let start = offs_tog[i] as usize;
+        let end = offs_tog[i + 1] as usize;
+        effects[start..end].sort_by(|a, b| {
+            a.to_word
+                .cmp(&b.to_word)
+                .then(a.order_tag.cmp(&b.order_tag))
+        });
+    }
+
+    CSR {
+        offs_on,
+        offs_off,
+        offs_tog,
+        effects,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -152,5 +292,47 @@ mod tests {
             validate_links(&links, &chunks),
             Err(LinkError::ToInIndexOutOfRange { .. })
         ));
+    }
+
+    #[test]
+    fn compute_offsets_and_map() {
+        let chunk_a_data = std::fs::read(fixtures().join("tiny_toggle.myc")).unwrap();
+        let chunk_b_data = std::fs::read(fixtures().join("noop.myc")).unwrap();
+        let chunk_a = parse_chunk(&chunk_a_data).unwrap();
+        let chunk_b = parse_chunk(&chunk_b_data).unwrap();
+        let chunks = vec![chunk_a, chunk_b];
+        let offs = compute_base_offsets(&chunks);
+        assert_eq!(offs.len(), 2);
+        assert_eq!(
+            offs[0],
+            ChunkOffsets {
+                input: 0,
+                output: 0,
+                internal: 0
+            }
+        );
+        assert_eq!(
+            offs[1],
+            ChunkOffsets {
+                input: 1,
+                output: 1,
+                internal: 1
+            }
+        );
+
+        let links = parse_links(&LINKS_BASIC).unwrap();
+        let csr = build_link_csr(&links, &chunks);
+        assert_eq!(csr.effects.len(), 1);
+        let effect = csr.effects[0];
+        // to_chunk (1) input index 0 -> global input bit 1
+        assert_eq!(effect.to_bit, 1);
+        let (word, mask) = crate::layout::bit_to_word(1);
+        assert_eq!(effect.to_word, word);
+        assert_eq!(effect.mask, mask);
+        assert!(!effect.to_is_internal);
+
+        // from_chunk (0) output index 0 -> global output bit 0
+        assert_eq!(csr.offs_on[0], 0);
+        assert_eq!(csr.offs_on[1], 1);
     }
 }


### PR DESCRIPTION
## Summary
- compute per-chunk base offsets for input/output/internal bit sections
- build CSR of links using global bit IDs
- test link mapping and global proposal target bits

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_689970f044a0832592d950b1af0d009a