### PR TITLE
Add WebGPU device initialization for WASM

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -12,3 +12,7 @@ crate-type = ["cdylib", "rlib"]
 wasm-bindgen = "0.2"
 wgpu = { version = "0.19", default-features = false, features = ["webgpu"], optional = true }
 petgraph = "0.6"
+
+[features]
+default = []
+webgpu = ["wgpu"]

--- a/engine/src/gpu/device.rs
+++ b/engine/src/gpu/device.rs
@@ -1,0 +1,38 @@
+use wasm_bindgen::JsValue;
+
+/// Initialize WebGPU and return the device and queue.
+///
+/// This function is only available when compiling for `wasm32` with the
+/// `webgpu` feature enabled. It selects the first available adapter and
+/// requests a device/queue pair using WebGPU-compatible limits.
+#[cfg(all(target_arch = "wasm32", feature = "webgpu"))]
+pub async fn init_device() -> Result<(wgpu::Device, wgpu::Queue), JsValue> {
+    // Instance is a lightweight handle in wgpu and doesn't need to be stored.
+    let instance = wgpu::Instance::default();
+
+    let adapter = instance
+        .request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        })
+        .await
+        .ok_or_else(|| JsValue::from_str("No suitable GPU adapters found"))?;
+
+    // No optional features are requested for the initial web build.
+    let features = wgpu::Features::empty();
+
+    let limits = wgpu::Limits::downlevel_webgl2_defaults();
+
+    let descriptor = wgpu::DeviceDescriptor {
+        label: Some("mycos-device"),
+        required_features: features,
+        required_limits: limits,
+        memory_hints: wgpu::MemoryHints::default(),
+    };
+
+    adapter
+        .request_device(&descriptor, None)
+        .await
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}

--- a/engine/src/gpu/mod.rs
+++ b/engine/src/gpu/mod.rs
@@ -1,0 +1,1 @@
+pub mod device;

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -4,6 +4,8 @@ pub mod layout;
 pub mod link;
 pub mod scc;
 
+#[cfg(all(target_arch = "wasm32", feature = "webgpu"))]
+pub mod gpu;
 pub use chunk::{
     parse_chunk, validate_chunk, Action, Connection, Error, MycosChunk, Section, Trigger,
 };
@@ -16,3 +18,6 @@ pub use link::{
     LinkError,
 };
 pub use scc::{build_internal_graph, scc_ids_and_topo_levels};
+
+#[cfg(all(target_arch = "wasm32", feature = "webgpu"))]
+pub use gpu::device::init_device;


### PR DESCRIPTION
## Summary
- add optional `webgpu` feature to the engine crate
- provide `gpu::device::init_device` for WASM WebGPU setup
- gate GPU module behind `webgpu` and wasm target

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6899730095508325a02a6190a2bbe74a