### PR TITLE
Add policy framework with cycle detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,10 +191,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "engine"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "petgraph",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wgpu",
 ]
@@ -352,6 +373,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +473,12 @@ checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "metal"
@@ -620,16 +665,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.142"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slotmap"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -12,7 +12,12 @@ crate-type = ["cdylib", "rlib"]
 wasm-bindgen = "0.2"
 wgpu = { version = "0.19", default-features = false, features = ["webgpu"], optional = true }
 petgraph = "0.6"
+serde = { version = "1.0", features = ["derive"] }
 
 [features]
 default = []
 webgpu = ["wgpu"]
+
+[dev-dependencies]
+insta = { version = "1.34.0", features = ["json"] }
+serde_json = "1.0"

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -2,6 +2,7 @@ pub mod chunk;
 pub mod csr;
 pub mod layout;
 pub mod link;
+pub mod policy;
 pub mod scc;
 
 #[cfg(all(target_arch = "wasm32", feature = "webgpu"))]
@@ -16,6 +17,9 @@ pub use layout::{
 pub use link::{
     build_link_csr, compute_base_offsets, parse_links, validate_links, ChunkOffsets, Link,
     LinkError,
+};
+pub use policy::{
+    clamp_commutative, freeze_last_stable, parity_quench, CycleDetector, ExecutionResult, Policy,
 };
 pub use scc::{build_internal_graph, scc_ids_and_topo_levels};
 

--- a/engine/src/policy.rs
+++ b/engine/src/policy.rs
@@ -1,0 +1,139 @@
+use crate::chunk::Action;
+use serde::Serialize;
+
+/// Policy applied when guards trigger.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum Policy {
+    /// Revert to last stable state seen before the cycle.
+    FreezeLastStable,
+    /// Resolve competing effects with commutative precedence.
+    ClampCommutative,
+    /// Toggle bits once based on cycle parity.
+    ParityQuench,
+}
+
+/// Result of executing with guards and policies applied.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecutionResult {
+    pub rounds: u32,
+    pub effects_applied: u64,
+    pub oscillator: bool,
+    pub period: u32,
+    pub policy: Option<Policy>,
+    pub internals: Vec<u32>,
+    pub outputs: Vec<u32>,
+}
+
+/// Ring buffer based cycle detector using 128-bit hashes of the internal state.
+pub struct CycleDetector {
+    ring: Vec<u128>,
+    pos: usize,
+}
+
+impl CycleDetector {
+    pub fn new(window: usize) -> Self {
+        Self {
+            ring: vec![0; window],
+            pos: 0,
+        }
+    }
+
+    /// Observe a new internal state. Returns `Some(period)` when a cycle is
+    /// detected, otherwise `None`.
+    pub fn observe(&mut self, state: &[u32]) -> Option<u32> {
+        let h = hash_state(state);
+        for i in 0..self.ring.len() {
+            if self.ring[i] == h {
+                let period = (self.ring.len() + self.pos - i) % self.ring.len();
+                self.ring[self.pos] = h;
+                self.pos = (self.pos + 1) % self.ring.len();
+                return Some(period as u32);
+            }
+        }
+        self.ring[self.pos] = h;
+        self.pos = (self.pos + 1) % self.ring.len();
+        None
+    }
+}
+
+/// Simple 128-bit FNV-1a style hash matching the GPU implementation.
+fn hash_state(words: &[u32]) -> u128 {
+    let mut h0: u32 = 0x811c9dc5;
+    let mut h1: u32 = 0x811c9dc5;
+    let mut h2: u32 = 0x811c9dc5;
+    let mut h3: u32 = 0x811c9dc5;
+    for &w in words {
+        h0 = (h0 ^ w).wrapping_mul(0x0100_0193);
+        h1 = (h1 ^ (w >> 1)).wrapping_mul(0x0100_0193);
+        h2 = (h2 ^ (w >> 2)).wrapping_mul(0x0100_0193);
+        h3 = (h3 ^ (w >> 3)).wrapping_mul(0x0100_0193);
+    }
+    ((h0 as u128) << 96) | ((h1 as u128) << 64) | ((h2 as u128) << 32) | (h3 as u128)
+}
+
+/// Apply the `freeze_last_stable` policy by restoring `curr` to `stable`.
+pub fn freeze_last_stable(curr: &mut [u32], stable: &[u32]) {
+    for (c, s) in curr.iter_mut().zip(stable.iter()) {
+        *c = *s;
+    }
+}
+
+/// Resolve a set of `Action`s using commutative precedence.
+pub fn clamp_commutative(actions: &[Action]) -> Option<Action> {
+    let mut disable = false;
+    let mut enable = false;
+    let mut toggle_count = 0u32;
+    for &a in actions {
+        match a {
+            Action::Disable => disable = true,
+            Action::Enable => enable = true,
+            Action::Toggle => toggle_count += 1,
+        }
+    }
+    if disable {
+        Some(Action::Disable)
+    } else if enable {
+        Some(Action::Enable)
+    } else if toggle_count % 2 == 1 {
+        Some(Action::Toggle)
+    } else {
+        None
+    }
+}
+
+/// Apply the `parity_quench` policy which toggles bits based on cycle parity.
+pub fn parity_quench(curr: &mut [u32], period: u32) {
+    if period % 2 == 1 {
+        for w in curr.iter_mut() {
+            *w = !*w;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_json_snapshot;
+    use serde_json::json;
+
+    #[test]
+    fn cycle_detection_and_freeze_snapshot() {
+        let mut det = CycleDetector::new(8);
+        let mut state = vec![1u32];
+        let stable = vec![0u32];
+        assert!(det.observe(&state).is_none());
+        state[0] = 3;
+        assert!(det.observe(&state).is_none());
+        state[0] = 2;
+        assert!(det.observe(&state).is_none());
+        state[0] = 1;
+        let period = det.observe(&state).unwrap();
+        let mut final_state = state.clone();
+        freeze_last_stable(&mut final_state, &stable);
+        let res = json!({
+            "period": period,
+            "final_state": final_state,
+        });
+        assert_json_snapshot!("freeze_last_stable", res);
+    }
+}

--- a/engine/src/snapshots/engine__policy__tests__freeze_last_stable.snap
+++ b/engine/src/snapshots/engine__policy__tests__freeze_last_stable.snap
@@ -1,0 +1,11 @@
+---
+source: engine/src/policy.rs
+assertion_line: 137
+expression: res
+---
+{
+  "final_state": [
+    0
+  ],
+  "period": 3
+}


### PR DESCRIPTION
## Summary
- introduce policy module with cycle detection and policy implementations
- expose policy utilities through library interface
- capture snapshot for freeze_last_stable behavior

## Testing
- `cargo build`
- `cargo test`
- `cargo clippy -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6899798fbfd08325aa6a6ec1260fef88