### PR TITLE
Add deployment workflow for GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,57 @@
+name: Deploy Web
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install wasm-bindgen
+        run: cargo install wasm-bindgen-cli
+
+      - name: Build WASM
+        working-directory: engine
+        run: |
+          cargo build --target wasm32-unknown-unknown --release
+          wasm-bindgen --target web --out-dir pkg target/wasm32-unknown-unknown/release/mycos.wasm
+
+      - name: Copy assets
+        run: |
+          mkdir -p web/engine
+          cp -r engine/pkg web/engine/pkg
+          mkdir -p web/public
+          cp -r fixtures web/public/fixtures
+
+      - name: Install web deps
+        working-directory: web
+        run: npm ci
+
+      - name: Build web
+        working-directory: web
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./web/dist


### PR DESCRIPTION
## Summary
- build and deploy web app to GitHub Pages on pushes to `main`

## Testing
- `cargo fmt --all -- --check -v`
- `cargo build`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `npm run lint`
- `npm run format:check`

------
https://chatgpt.com/codex/tasks/task_e_68999b0de1788325b1c62d9e71dd1924