### PR TITLE
Fix wasm build path in Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         working-directory: engine
         run: |
           cargo build --target wasm32-unknown-unknown --release
-          wasm-bindgen --target web --out-dir pkg target/wasm32-unknown-unknown/release/mycos.wasm
+          wasm-bindgen --target web --out-dir pkg target/wasm32-unknown-unknown/release/engine.wasm
 
       - name: Copy assets
         run: |

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ cd engine
 cargo build --target wasm32-unknown-unknown --release
 
 # Generate bindings
-wasm-bindgen --target web --out-dir ../web/pkg target/wasm32-unknown-unknown/release/mycos.wasm
+wasm-bindgen --target web --out-dir pkg target/wasm32-unknown-unknown/release/engine.wasm
+cp -r pkg ../web/engine/pkg
 
 # Start web UI
 cd ../web


### PR DESCRIPTION
## Summary
- fix GitHub Pages workflow to use correct engine.wasm output
- document updated build steps for wasm bindings in README

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6899a0f7d5088325928c88e5a820a4af