### PR TITLE
Fix wasm build path in deploy workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         working-directory: engine
         run: |
           cargo build --target wasm32-unknown-unknown --release
-          wasm-bindgen --target web --out-dir pkg target/wasm32-unknown-unknown/release/engine.wasm
+          wasm-bindgen --target web --out-dir pkg ../target/wasm32-unknown-unknown/release/engine.wasm
 
       - name: Copy assets
         run: |


### PR DESCRIPTION
## Summary
- fix path to wasm artifact for wasm-bindgen in Deploy Web workflow

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy`
- `npm ci` *(fails: Error fetching release: write EPROTO ... wrong version number)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file after missing deps)*
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689baed4a4ec83259e4b91346a4dd6e4