### PR TITLE
chore(web): configure GitHub Pages base path

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -50,7 +50,7 @@ let inputsWords = new Uint32Array(0);
 let outputsWords = new Uint32Array(0);
 
 async function loadFixture(name: string): Promise<void> {
-  const url = `/fixtures/${name}.myc`;
+  const url = `${import.meta.env.BASE_URL}fixtures/${name}.myc`;
   const buffer = await fetch(url).then((r) => r.arrayBuffer());
   const header = parseHeader(buffer);
   loadChunks([buffer]);

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -43,6 +43,7 @@ function copyAssets(): void {
 }
 
 export default defineConfig({
+  base: '/mycos/',
   build: {
     target: 'esnext',
   },


### PR DESCRIPTION
## Summary
- serve web app from `/mycos/` base path for GitHub Pages
- load fixtures relative to deployment base URL

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689bbe940c60832588009f204d2cf8be