### PR TITLE
Add placeholder GPU batch evaluation API

### DIFF
--- a/engine/src/gpu_eval.rs
+++ b/engine/src/gpu_eval.rs
@@ -1,0 +1,64 @@
+use crate::genome::Genome;
+
+/// Placeholder task description for evaluation.
+///
+/// A real task would include scoring logic and I/O mapping,
+/// but for now it is an empty struct allowing the evaluation
+/// API to compile on all targets.
+#[derive(Clone, Debug, Default)]
+pub struct Task;
+
+/// Inputs for a single episode within a batch evaluation.
+#[derive(Clone, Debug, Default)]
+pub struct Episode {
+    /// Input bits encoded as 32-bit words, LSB first.
+    pub inputs: Vec<u32>,
+}
+
+/// Per-episode metrics returned by `evaluate_batch`.
+#[derive(Clone, Debug, Default)]
+pub struct EpisodeMetrics {
+    /// Number of wavefront rounds executed.
+    pub rounds: u32,
+    /// Number of effects applied.
+    pub effects: u32,
+    /// Whether an oscillator was detected.
+    pub oscillator: bool,
+    /// Oscillation period when `oscillator` is true.
+    pub period: u32,
+}
+
+/// Result of evaluating a genome over a sequence of episodes.
+#[derive(Clone, Debug, Default)]
+pub struct FitnessResult {
+    /// Fitness score for the genome. Currently always `0.0`.
+    pub fitness: f32,
+    /// Metrics collected for each episode.
+    pub metrics: Vec<EpisodeMetrics>,
+    /// Captured output words per episode.
+    pub outputs: Vec<Vec<u32>>,
+}
+
+/// Evaluate a batch of genomes against a task and episodes.
+///
+/// This function provides a temporary CPU-side implementation so that the
+/// evaluation API compiles even when the `webgpu` feature is disabled. A future
+/// version will upload the genomes to the GPU and execute the wavefront kernels
+/// in parallel.
+pub fn evaluate_batch(
+    genomes: &[Genome],
+    _task: &Task,
+    episodes: &[Episode],
+) -> Vec<FitnessResult> {
+    let mut results = Vec::with_capacity(genomes.len());
+    for _genome in genomes {
+        let metrics = vec![EpisodeMetrics::default(); episodes.len()];
+        let outputs = vec![Vec::<u32>::new(); episodes.len()];
+        results.push(FitnessResult {
+            fitness: 0.0,
+            metrics,
+            outputs,
+        });
+    }
+    results
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -4,6 +4,7 @@ pub mod crossover;
 pub mod csr;
 pub mod embed;
 pub mod genome;
+pub mod gpu_eval;
 pub mod layout;
 pub mod link;
 pub mod mutations;
@@ -21,6 +22,7 @@ pub use crossover::crossover;
 pub use csr::{build_csr, Effect, CSR};
 pub use embed::{execute_gated_alias, execute_gated_copy, parse_embeds, Embed, EmbedError, IoMode};
 pub use genome::{ChunkGene, ConnGene, Genome, GenomeMeta, LinkGene, ValidationError};
+pub use gpu_eval::{evaluate_batch, Episode, EpisodeMetrics, FitnessResult, Task};
 pub use layout::{
     bit_to_word, clr_bit, connection_table_offset, section_offsets, set_bit, xor_bit, HEADER_BYTES,
 };


### PR DESCRIPTION
## Summary
- add minimal GPU batch evaluation module with task, episode, and metrics structures
- re-export evaluation API from library

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_689bbfff8d6c8325b0940c07430e4b6f