### PR TITLE
fix vite base path for gh pages

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -42,8 +42,10 @@ function copyAssets(): void {
   }
 }
 
-export default defineConfig({
-  base: '/mycos/',
+const repoBase = process.env.GITHUB_REPOSITORY?.split('/')[1];
+
+export default defineConfig(({ command }) => ({
+  base: command === 'build' && repoBase ? `/${repoBase}/` : '/',
   build: {
     target: 'esnext',
   },
@@ -56,4 +58,4 @@ export default defineConfig({
       },
     },
   ],
-});
+}));


### PR DESCRIPTION
## Summary
- set Vite base path dynamically using GITHUB_REPOSITORY to deploy under the repo name

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy -- -D warnings`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689bc18a0ad88325a2c3336e377a1e70