### PR TITLE
ci: deploy pages after merge

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,15 +4,22 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 
 permissions:
   contents: write
 
 jobs:
   deploy:
+    if: ${{ github.event_name == 'push' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0].merged == true) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.workflow_run.pull_requests[0].merge_commit_sha || github.sha }}
 
       - uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
## Summary
- deploy fresh pages after successful CI or direct pushes to main

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test --workspace`
- `cargo clippy --all-targets -- -D warnings`
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689bc41cd3608325b42ea576ea5db715