### PR TITLE
Implement task definitions and scoring framework

### DIFF
--- a/engine/src/gpu_eval.rs
+++ b/engine/src/gpu_eval.rs
@@ -1,12 +1,4 @@
-use crate::genome::Genome;
-
-/// Placeholder task description for evaluation.
-///
-/// A real task would include scoring logic and I/O mapping,
-/// but for now it is an empty struct allowing the evaluation
-/// API to compile on all targets.
-#[derive(Clone, Debug, Default)]
-pub struct Task;
+use crate::{genome::Genome, tasks::Task};
 
 /// Inputs for a single episode within a batch evaluation.
 #[derive(Clone, Debug, Default)]

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -10,6 +10,8 @@ pub mod link;
 pub mod mutations;
 pub mod policy;
 pub mod scc;
+pub mod scoring;
+pub mod tasks;
 
 #[cfg(all(target_arch = "wasm32", feature = "webgpu"))]
 pub mod api;
@@ -22,7 +24,7 @@ pub use crossover::crossover;
 pub use csr::{build_csr, Effect, CSR};
 pub use embed::{execute_gated_alias, execute_gated_copy, parse_embeds, Embed, EmbedError, IoMode};
 pub use genome::{ChunkGene, ConnGene, Genome, GenomeMeta, LinkGene, ValidationError};
-pub use gpu_eval::{evaluate_batch, Episode, EpisodeMetrics, FitnessResult, Task};
+pub use gpu_eval::{evaluate_batch, Episode, EpisodeMetrics, FitnessResult};
 pub use layout::{
     bit_to_word, clr_bit, connection_table_offset, section_offsets, set_bit, xor_bit, HEADER_BYTES,
 };
@@ -35,6 +37,11 @@ pub use policy::{
     clamp_commutative, freeze_last_stable, parity_quench, CycleDetector, ExecutionResult, Policy,
 };
 pub use scc::{build_internal_graph, scc_ids_and_topo_levels};
+pub use scoring::{score, ScoringSpec};
+pub use tasks::{
+    t00_wire_echo, t01_xor_2, t02_sr_latch, t03_pulse_counter, t04_cross_chunk_relay, EpisodeSpec,
+    Io, IoMap, Task,
+};
 
 #[cfg(all(target_arch = "wasm32", feature = "webgpu"))]
 pub use gpu::device::init_device;

--- a/engine/src/scoring.rs
+++ b/engine/src/scoring.rs
@@ -1,0 +1,111 @@
+use crate::tasks::{EpisodeSpec, Task};
+
+/// Scoring strategies supported by the engine.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ScoringSpec {
+    /// Measure Hamming similarity of outputs versus expected targets.
+    /// The score is `1.0 - H(outputs XOR targets) / M`, where `M` is the
+    /// number of observed output bits.
+    Hamming,
+}
+
+/// Compute a fitness score for a task given the captured outputs for each
+/// episode. `outputs` must have the same shape as `task.episodes`: a vector of
+/// episodes, each containing per-tick output words.
+pub fn score(task: &Task, outputs: &[Vec<Vec<u32>>]) -> f32 {
+    assert_eq!(task.episodes.len(), outputs.len());
+    match task.scoring {
+        ScoringSpec::Hamming => {
+            let mut total_score = 0.0f32;
+            for (spec, actual) in task.episodes.iter().zip(outputs.iter()) {
+                total_score += hamming_episode(spec, actual, task.io.outputs.len());
+            }
+            total_score / task.episodes.len() as f32
+        }
+    }
+}
+
+fn hamming_episode(spec: &EpisodeSpec, actual: &[Vec<u32>], output_bits: usize) -> f32 {
+    assert_eq!(spec.expected.len(), actual.len());
+    let mut total_bits = 0u32;
+    let mut diff_bits = 0u32;
+    for (expected_tick, actual_tick) in spec.expected.iter().zip(actual.iter()) {
+        assert_eq!(expected_tick.len(), actual_tick.len());
+        for (e, a) in expected_tick.iter().zip(actual_tick.iter()) {
+            diff_bits += (e ^ a).count_ones();
+        }
+        total_bits += output_bits as u32;
+    }
+    if total_bits == 0 {
+        1.0
+    } else {
+        1.0 - diff_bits as f32 / total_bits as f32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tasks::{
+        t00_wire_echo, t01_xor_2, t02_sr_latch, t03_pulse_counter, t04_cross_chunk_relay,
+    };
+
+    fn perfect_outputs(task: &Task) -> Vec<Vec<Vec<u32>>> {
+        task.episodes.iter().map(|e| e.expected.clone()).collect()
+    }
+
+    fn flipped_outputs(task: &Task) -> Vec<Vec<Vec<u32>>> {
+        let mut outs = perfect_outputs(task);
+        if let Some(first_tick) = outs.get_mut(0).and_then(|ep| ep.get_mut(0)) {
+            if let Some(word) = first_tick.get_mut(0) {
+                *word ^= 1; // flip least significant bit
+            }
+        }
+        outs
+    }
+
+    #[test]
+    fn score_wire_echo() {
+        let task = t00_wire_echo();
+        let good = perfect_outputs(&task);
+        let bad = flipped_outputs(&task);
+        assert_eq!(score(&task, &good), 1.0);
+        assert!(score(&task, &bad) < 1.0);
+    }
+
+    #[test]
+    fn score_xor2() {
+        let task = t01_xor_2();
+        let good = perfect_outputs(&task);
+        let bad = flipped_outputs(&task);
+        assert_eq!(score(&task, &good), 1.0);
+        assert!(score(&task, &bad) < 1.0);
+    }
+
+    #[test]
+    fn score_sr_latch() {
+        let task = t02_sr_latch();
+        let good = perfect_outputs(&task);
+        let bad = flipped_outputs(&task);
+        assert_eq!(score(&task, &good), 1.0);
+        assert!(score(&task, &bad) < 1.0);
+    }
+
+    #[test]
+    fn score_pulse_counter() {
+        let task = t03_pulse_counter();
+        let good = perfect_outputs(&task);
+        let bad = flipped_outputs(&task);
+        assert_eq!(score(&task, &good), 1.0);
+        assert!(score(&task, &bad) < 1.0);
+    }
+
+    #[test]
+    fn score_cross_chunk_relay() {
+        let task = t04_cross_chunk_relay();
+        let good = perfect_outputs(&task);
+        let bad = flipped_outputs(&task);
+        assert_eq!(score(&task, &good), 1.0);
+        assert!(score(&task, &bad) < 1.0);
+    }
+}

--- a/engine/src/tasks.rs
+++ b/engine/src/tasks.rs
@@ -1,0 +1,195 @@
+use crate::scoring::ScoringSpec;
+
+/// Mapping of task-controlled inputs and observed outputs.
+#[derive(Clone, Debug)]
+pub struct Io {
+    pub chunk_id: u32,
+    pub bit_idx: u32,
+}
+
+#[derive(Clone, Debug)]
+pub struct IoMap {
+    pub inputs: Vec<Io>,
+    pub outputs: Vec<Io>,
+}
+
+/// Specification of a single episode: initial state and stimuli per tick with
+/// expected outputs used for scoring.
+#[derive(Clone, Debug)]
+pub struct EpisodeSpec {
+    /// Input bit vectors per tick.
+    pub stimulus: Vec<Vec<u32>>,
+    /// Expected output bit vectors per tick.
+    pub expected: Vec<Vec<u32>>,
+}
+
+/// Complete task description.
+#[derive(Clone, Debug)]
+pub struct Task {
+    pub name: &'static str,
+    pub io: IoMap,
+    pub episodes: Vec<EpisodeSpec>,
+    pub tick_budget: u32,
+    pub scoring: ScoringSpec,
+}
+
+/// T-00 Wire-Echo: output mirrors input on the same tick.
+pub fn t00_wire_echo() -> Task {
+    Task {
+        name: "T-00 Wire-Echo",
+        io: IoMap {
+            inputs: vec![Io {
+                chunk_id: 0,
+                bit_idx: 0,
+            }],
+            outputs: vec![Io {
+                chunk_id: 0,
+                bit_idx: 0,
+            }],
+        },
+        episodes: vec![
+            EpisodeSpec {
+                stimulus: vec![vec![1]],
+                expected: vec![vec![1]],
+            },
+            EpisodeSpec {
+                stimulus: vec![vec![0]],
+                expected: vec![vec![0]],
+            },
+        ],
+        tick_budget: 1,
+        scoring: ScoringSpec::Hamming,
+    }
+}
+
+/// T-01 XOR-2: outputs XOR of two inputs.
+pub fn t01_xor_2() -> Task {
+    Task {
+        name: "T-01 XOR-2",
+        io: IoMap {
+            inputs: vec![
+                Io {
+                    chunk_id: 0,
+                    bit_idx: 0,
+                },
+                Io {
+                    chunk_id: 0,
+                    bit_idx: 1,
+                },
+            ],
+            outputs: vec![Io {
+                chunk_id: 0,
+                bit_idx: 2,
+            }],
+        },
+        episodes: vec![
+            EpisodeSpec {
+                stimulus: vec![vec![0b00]],
+                expected: vec![vec![0]],
+            },
+            EpisodeSpec {
+                stimulus: vec![vec![0b01]],
+                expected: vec![vec![1]],
+            },
+            EpisodeSpec {
+                stimulus: vec![vec![0b10]],
+                expected: vec![vec![1]],
+            },
+            EpisodeSpec {
+                stimulus: vec![vec![0b11]],
+                expected: vec![vec![0]],
+            },
+        ],
+        tick_budget: 1,
+        scoring: ScoringSpec::Hamming,
+    }
+}
+
+/// T-02 SR-Latch: implements a basic set-reset latch.
+pub fn t02_sr_latch() -> Task {
+    Task {
+        name: "T-02 SR-Latch",
+        io: IoMap {
+            inputs: vec![
+                Io {
+                    chunk_id: 0,
+                    bit_idx: 0,
+                }, // S
+                Io {
+                    chunk_id: 0,
+                    bit_idx: 1,
+                }, // R
+            ],
+            outputs: vec![Io {
+                chunk_id: 0,
+                bit_idx: 2,
+            }], // Q
+        },
+        episodes: vec![
+            // Set then hold
+            EpisodeSpec {
+                stimulus: vec![vec![0b01], vec![0b00]],
+                expected: vec![vec![1], vec![1]],
+            },
+            // Reset then hold
+            EpisodeSpec {
+                stimulus: vec![vec![0b10], vec![0b00]],
+                expected: vec![vec![0], vec![0]],
+            },
+        ],
+        tick_budget: 2,
+        scoring: ScoringSpec::Hamming,
+    }
+}
+
+/// T-03 Pulse-Counter: counts incoming pulses modulo 4 using two output bits.
+pub fn t03_pulse_counter() -> Task {
+    Task {
+        name: "T-03 Pulse-Counter",
+        io: IoMap {
+            inputs: vec![Io {
+                chunk_id: 0,
+                bit_idx: 0,
+            }],
+            outputs: vec![
+                Io {
+                    chunk_id: 0,
+                    bit_idx: 1,
+                },
+                Io {
+                    chunk_id: 0,
+                    bit_idx: 2,
+                },
+            ],
+        },
+        episodes: vec![EpisodeSpec {
+            stimulus: vec![vec![1], vec![1], vec![1]],
+            expected: vec![vec![1], vec![2], vec![3]],
+        }],
+        tick_budget: 3,
+        scoring: ScoringSpec::Hamming,
+    }
+}
+
+/// T-04 Cross-Chunk Relay: relays an input from chunk 0 to an output on chunk 1 with one tick delay.
+pub fn t04_cross_chunk_relay() -> Task {
+    Task {
+        name: "T-04 Cross-Chunk Relay",
+        io: IoMap {
+            inputs: vec![Io {
+                chunk_id: 0,
+                bit_idx: 0,
+            }],
+            outputs: vec![Io {
+                chunk_id: 1,
+                bit_idx: 0,
+            }],
+        },
+        episodes: vec![EpisodeSpec {
+            stimulus: vec![vec![1], vec![0]],
+            expected: vec![vec![0], vec![1]],
+        }],
+        tick_budget: 2,
+        scoring: ScoringSpec::Hamming,
+    }
+}


### PR DESCRIPTION
## Summary
- add comprehensive task specifications and built-in tasks T-00 through T-04
- introduce Hamming-based scoring with unit tests
- wire tasks and scoring into engine API

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_689bc5958ac48325b6dbd94c7ccf5950