### PR TITLE
Enable webgpu feature for wasm-pack build

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -21,7 +21,7 @@ function buildEngine(): void {
       process.platform === 'win32' ? 'wasm-pack.exe' : 'wasm-pack'
     );
     const wasmPackCmd = existsSync(wasmPackPath) ? wasmPackPath : 'wasm-pack';
-    execSync(`${wasmPackCmd} build --target web --dev`, {
+    execSync(`${wasmPackCmd} build --target web --dev -- --features webgpu`, {
       cwd: engineSrcDir,
       stdio: 'inherit',
     });


### PR DESCRIPTION
## Summary
- enable the `webgpu` feature when building the engine's WASM package so bindings are exported

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689bc81b16848325b2bf417466d6102d