### PR TITLE
Enable webgpu feature for wasm-pack build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,11 +216,13 @@ dependencies = [
  "bitvec",
  "getrandom",
  "insta",
+ "js-sys",
  "petgraph",
  "rand",
  "serde",
  "serde_json",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
  "wgpu",
 ]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -10,6 +10,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
 wgpu = { version = "0.19", default-features = false, features = ["webgpu"], optional = true }
 petgraph = "0.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/engine/src/gpu/device.rs
+++ b/engine/src/gpu/device.rs
@@ -28,7 +28,6 @@ pub async fn init_device() -> Result<(wgpu::Device, wgpu::Queue), JsValue> {
         label: Some("mycos-device"),
         required_features: features,
         required_limits: limits,
-        memory_hints: wgpu::MemoryHints::default(),
     };
 
     adapter

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -21,7 +21,7 @@ function buildEngine(): void {
       process.platform === 'win32' ? 'wasm-pack.exe' : 'wasm-pack'
     );
     const wasmPackCmd = existsSync(wasmPackPath) ? wasmPackPath : 'wasm-pack';
-    execSync(`${wasmPackCmd} build --target web --dev`, {
+    execSync(`${wasmPackCmd} build --target web --dev -- --features webgpu`, {
       cwd: engineSrcDir,
       stdio: 'inherit',
     });


### PR DESCRIPTION
## Summary
- enable the `webgpu` feature when building the engine's WASM package so bindings are exported
- add missing wasm dependencies and remove unsupported `memory_hints` field to allow WebGPU builds

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy`
- `cargo build --target wasm32-unknown-unknown --features webgpu`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689bc81b16848325b2bf417466d6102d