### PR TITLE
Refactor: address clippy pedantic lints

### DIFF
--- a/engine/src/chunk.rs
+++ b/engine/src/chunk.rs
@@ -330,8 +330,7 @@ fn encode_tlv(out: &mut Vec<u8>, t: u16, value: &[u8]) {
 pub fn validate_chunk(chunk: &MycosChunk) -> Result<(), Error> {
     for conn in &chunk.connections {
         match (conn.from_section, conn.to_section) {
-            (Section::Input, Section::Internal)
-            | (Section::Internal, Section::Internal)
+            (Section::Input | Section::Internal, Section::Internal)
             | (Section::Internal, Section::Output) => {}
             _ => {
                 return Err(Error::InvalidConnectionEdge {

--- a/engine/src/embed.rs
+++ b/engine/src/embed.rs
@@ -137,7 +137,7 @@ pub fn execute_gated_copy(parent: &mut MycosChunk, child: &mut MycosChunk, embed
     if gate_now {
         let (ci, co, cn) = cpu_ref::execute(child);
         child.input_bits = ci;
-        child.output_bits = co.clone();
+        child.output_bits.clone_from(&co);
         child.internal_bits = cn;
         for (c_bit, p_bit) in &embed.map_out {
             let val = get_bit(&co, *c_bit);

--- a/engine/src/genome.rs
+++ b/engine/src/genome.rs
@@ -264,7 +264,7 @@ impl ConnGene {
             return Err(ValidationError::InvalidAction(self.action));
         }
         match (self.from_section, self.to_section) {
-            (0, 1) | (1, 1) | (1, 2) => Ok(()),
+            (0, 1) | (1, 1 | 2) => Ok(()),
             _ => Err(ValidationError::InvalidConnEdge {
                 from_section: self.from_section,
                 to_section: self.to_section,

--- a/engine/src/scc.rs
+++ b/engine/src/scc.rs
@@ -60,7 +60,7 @@ pub fn scc_ids_and_topo_levels(chunk: &MycosChunk) -> (Vec<usize>, Vec<usize>) {
     }
 
     while let Some(u) = queue.pop_front() {
-        for &v in dag[u].iter() {
+        for &v in &dag[u] {
             if levels[v] < levels[u] + 1 {
                 levels[v] = levels[u] + 1;
             }


### PR DESCRIPTION
## Summary
- Reduce or-pattern nesting in `validate_chunk`
- Simplify connection edge validation in `Genome`
- Avoid redundant clones and iterator usage

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_689bd003dd1c8325aabace1cc3b8b89b