### PR TITLE
Run deploy workflow on main pushes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,22 +4,15 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
 
 permissions:
   contents: write
 
 jobs:
   deploy:
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0].merged == true && github.event.workflow_run.head_branch == 'main') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.workflow_run.pull_requests[0].merge_commit_sha || github.sha }}
 
       - uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
## Summary
- run Pages deployment workflow on push to main or manual dispatch

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy`
- `npm ci` *(failed: Downloading release from https://github.com/rustwasm/wasm-pack/releases/... wrong version number)*
- `npm ci --ignore-scripts`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689bcfeb00a48325a0d00ec1d8136691