### PR TITLE
Add PR merge deployment workflow

### DIFF
--- a/.github/workflows/deploy-web-pr.yml
+++ b/.github/workflows/deploy-web-pr.yml
@@ -1,0 +1,60 @@
+name: Deploy Web on PR Merge
+
+on:
+  pull_request:
+    branches: [main]
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install wasm-bindgen
+        run: cargo install wasm-bindgen-cli
+
+      - name: Build WASM
+        working-directory: engine
+        run: |
+          cargo build --target wasm32-unknown-unknown --release
+          wasm-bindgen --target web --out-dir pkg ../target/wasm32-unknown-unknown/release/engine.wasm
+
+      - name: Copy assets
+        run: |
+          mkdir -p web/engine
+          cp -r engine/pkg web/engine/pkg
+          mkdir -p web/public
+          cp -r fixtures web/public/fixtures
+
+      - name: Install web deps
+        working-directory: web
+        run: npm ci
+
+      - name: Build web
+        working-directory: web
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./web/dist


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy web on merged PRs to main

## Testing
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo test`
- `cargo clippy -- -D warnings`
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689bf6b1480483258e10205c5d9c7fcb